### PR TITLE
add item loss and recovery

### DIFF
--- a/dungeon-delve/Assets/Scripts/Equipment/Equipment.cs
+++ b/dungeon-delve/Assets/Scripts/Equipment/Equipment.cs
@@ -21,12 +21,38 @@ public class Equipment
 
     public static void AddEq(Equipment eq)
     {
+        if(eq == null)
+        {
+            return;
+        }
+
         for(int i = 0; i < eq_inventory.Length; i++)
         {
             if(eq_inventory[i] == null)
             {
                 eq_inventory[i] = eq;
                 return;
+            }
+        }
+    }
+    public static void AddEq(Equipment[] eqArray)
+    {
+        if(eqArray == null)
+        {
+            return;
+        }
+
+        int i = 0;
+        foreach (Equipment eq in eqArray)
+        {
+            while(i < eq_inventory.Length)
+            {
+                if (eq_inventory[i] == null)
+                {
+                    eq_inventory[i] = eq;
+                    break;
+                }
+                i++;
             }
         }
     }

--- a/dungeon-delve/Assets/Scripts/Equipment/LostEquipment.cs
+++ b/dungeon-delve/Assets/Scripts/Equipment/LostEquipment.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+
+public class LostEquipment
+{
+    private int encounter;
+    private List<Equipment> eq = new List<Equipment>();
+    private LostEquipment next;
+
+    private static LostEquipment head;
+
+    private LostEquipment(int encounterNumber, Equipment[] equipment)
+    {
+        encounter = encounterNumber;
+        foreach (Equipment e in equipment)
+        {
+            eq.Add(e);
+        }
+    }
+
+    public static void Insert(int encounterNumber, Equipment[] lostEq)
+    {
+        if (head == null)
+        {
+            head = new LostEquipment(encounterNumber, lostEq);
+            return;
+        }
+        if (head.encounter < encounterNumber)
+        {
+            LostEquipment temp = new LostEquipment(encounterNumber, lostEq);
+            temp.next = head;
+            head = temp;
+            return;
+        }
+        if (head.encounter == encounterNumber)
+        {
+            foreach (Equipment e in lostEq)
+            {
+                head.eq.Add(e);
+            }
+            return;
+        }
+        if(head.next == null)
+        {
+            head.next = new LostEquipment(encounterNumber, lostEq);
+        }
+        InsertLower(head, encounterNumber, lostEq);
+    }
+
+    private static void InsertLower(LostEquipment previousNode, 
+        int encounterNumber, Equipment[] lostEq)
+    {
+        if (previousNode.next.encounter < encounterNumber)
+        {
+            LostEquipment temp = new LostEquipment(encounterNumber, lostEq);
+            temp.next = previousNode.next;
+            previousNode.next = temp;
+            return;
+        }
+        if (previousNode.next.encounter == encounterNumber)
+        {
+            foreach (Equipment e in lostEq)
+            {
+                previousNode.next.eq.Add(e);
+            }
+            return;
+        }
+        if (previousNode.next.next == null)
+        {
+            previousNode.next.next = new LostEquipment(encounterNumber, lostEq);
+        }
+        InsertLower(previousNode.next, encounterNumber, lostEq);
+    }
+
+    public static Equipment[] GetLostEquipment(int encounterNumber)
+    {
+        if (head == null)
+        {
+            return null;
+        }
+        //because this is a sorted list, if the encounter number is greater than this encounter, it is not in the list
+        if (head.encounter > encounterNumber)
+        {
+            return null;
+        }
+        if (head.encounter == encounterNumber)
+        {
+            Equipment[] equipment = head.eq.ToArray();
+            head = head.next;
+            return equipment;
+        }
+        return GetLostEquipment(head, encounterNumber);
+    }
+
+    private static Equipment[] GetLostEquipment(LostEquipment node, int encounterNumber)
+    {
+        if(node.next == null)
+        {
+            return null;
+        }
+        //because this is a sorted list, if the encounter number is greater than this encounter, it is not in the list
+        if(node.next.encounter > encounterNumber)
+        {
+            return null;
+        }
+        if(node.next.encounter == encounterNumber)
+        {
+            Equipment[] equipment = node.eq.ToArray();
+            node.next = node.next.next;
+            return equipment;
+        }
+        return GetLostEquipment(node.next, encounterNumber);
+    }
+}

--- a/dungeon-delve/Assets/Scripts/Equipment/LostEquipment.cs.meta
+++ b/dungeon-delve/Assets/Scripts/Equipment/LostEquipment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e7526bf398f1b447b3eda7e2689fbd3

--- a/dungeon-delve/Assets/Scripts/MercenaryScripts/MonsterEncounter.cs
+++ b/dungeon-delve/Assets/Scripts/MercenaryScripts/MonsterEncounter.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine.SceneManagement;
 using UnityEngine;
 
@@ -18,6 +19,8 @@ public class MonsterEncounter : MonoBehaviour
 
     public delegate void mercTick();
     public static event mercTick OnMercTick;
+
+    private static List<Equipment> deadEq = new List<Equipment>();
 
 
     private void Awake()
@@ -128,10 +131,6 @@ public class MonsterEncounter : MonoBehaviour
             {
                 MercObject.Party[i].UpdateHealth(HeroMercs[i].health);
             }
-            else
-            {
-                MercObject.DeletePartyMemeber(i);
-            }
         }
 
         //guarentees a hero in the first slot to prevent nullreference (this is gross and I hate it)
@@ -147,12 +146,30 @@ public class MonsterEncounter : MonoBehaviour
                 }
             }
         }
+        Equipment.AddEq(deadEq.ToArray());
+        Equipment[] e = LostEquipment.GetLostEquipment(PlayerData.levelsCleared);
+        if (e != null)
+        {
+            Debug.Log("regained eq");
+        }
+        Equipment.AddEq(e);
+        //Equipment.AddEq(LostEquipment.GetLostEquipment(PlayerData.levelsCleared));
         PlayerData.levelsCleared += 1;
         SceneManager.LoadScene("EncounterWin");
     }
 
     public static void QuereyLoss(MercenaryController deadHero)
     {
+        MercObject merc = MercObject.Party[deadHero.partyOrder];
+        if (merc.armor != null)
+        {
+            deadEq.Add(merc.armor);
+        }
+        if (merc.weapon != null)
+        {
+            deadEq.Add(merc.weapon);
+        }
+        MercObject.DeletePartyMemeber(deadHero.partyOrder);
         HeroMercs[deadHero.partyOrder] = null;
         foreach (MercenaryController mercenary in HeroMercs)
         {
@@ -163,6 +180,7 @@ public class MonsterEncounter : MonoBehaviour
             }
         }
         Debug.Log("Monster Win");
+        LostEquipment.Insert(PlayerData.levelsCleared, deadEq.ToArray());
         SceneManager.LoadScene("EncounterLoss");
     }
 

--- a/dungeon-delve/Assets/Scripts/Traps/TrapResult.cs
+++ b/dungeon-delve/Assets/Scripts/Traps/TrapResult.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using TMPro;
+using System.Collections.Generic;
 
 public class TrapResult : MonoBehaviour
 {
@@ -9,6 +10,8 @@ public class TrapResult : MonoBehaviour
     [Header("Loss")]
     [SerializeField] private GameObject lossScreen;
     [SerializeField] private TextMeshProUGUI damageText;
+
+    private List<Equipment> deadEq = new List<Equipment>();
 
     private void Start()
     {
@@ -44,8 +47,16 @@ public class TrapResult : MonoBehaviour
             }
             Debug.Log("party member " + i + " with " + merc.GetHealth() + " is taking " + trap.damage + " damage");
             merc.UpdateHealth(merc.GetHealth() - trap.damage);
-            if(merc.GetHealth() < 0)
+            if(merc.GetHealth() <= 0)
             {
+                if (merc.armor != null)
+                {
+                    deadEq.Add(merc.armor);
+                }
+                if (merc.weapon != null)
+                {
+                    deadEq.Add(merc.weapon);
+                }
                 MercObject.DeletePartyMemeber(i);
             }
             i++;
@@ -72,11 +83,13 @@ public class TrapResult : MonoBehaviour
         //since we always guarentee that the first slot is filled, if it is not then everyone is dead
         if (MercObject.Party[0] != null)
         {
-            PlayerData.levelsCleared += 1;
+            Equipment.AddEq(deadEq.ToArray());
+            Equipment.AddEq(LostEquipment.GetLostEquipment(PlayerData.levelsCleared));
+            PlayerData.levelsCleared ++;
             SceneManager.LoadScene("EncounterWin");
             return;
         }
-
+        LostEquipment.Insert(PlayerData.levelsCleared ,deadEq.ToArray());
         SceneManager.LoadScene("EncounterLoss");    
     }
 }


### PR DESCRIPTION
closes #103 
also adds a feature that causes heroes to loose equipment to an encounter, I thought this was in this sprint but its not an issue at all. It was a feature of the board game so I implemented it.