### PR TITLE
Fix mead horn null reference exception

### DIFF
--- a/dungeon-delve/Assets/Scripts/Items/MeadHorn.cs
+++ b/dungeon-delve/Assets/Scripts/Items/MeadHorn.cs
@@ -17,7 +17,7 @@ public class MeadHorn : MonoBehaviour, IItem
         {
             foreach(HeroController hero in encounter.GetHeroes())
             {
-                hero.DamageBoost(1);
+                hero?.DamageBoost(1);
             }
         }
     }


### PR DESCRIPTION
It tried to apply the damage boost to null heroes so it would work if the party was full but not otherwise.
closes #178 